### PR TITLE
add linux-image-amd64 and linux-image-arm64 to exclusions

### DIFF
--- a/remove-old-kernels.sh
+++ b/remove-old-kernels.sh
@@ -12,7 +12,8 @@ OLD_KERNELS=$(
     dpkg --get-selections |
         grep -v "linux-headers-generic" |
         grep -v "linux-image-generic" |
-        grep -v "linux-image-generic" |
+        grep -v "linux-image-amd64" |
+        grep -v "linux-image-arm64" |
         grep -v "${IN_USE%%-generic}" |
         grep -Ei 'linux-image|linux-headers|linux-modules' |
         awk '{ print $1 }'


### PR DESCRIPTION
We tried the script on one of our servers and it tried to uninstall the linux-image-am64 packet, which is the kernel meta packet on debian. Additionally I added the linux-image-arm64 packet, which is the meta packet on arm64 based systems.