### PR TITLE
Improved output whitespacing and general readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ the list of old kernels and modules printed in the dry run
  - awk
 
        apt install gawk
-   
+
 ### authors:
 - alex Burdusel and @eitch on https://askubuntu.com/a/1409370/34298
 - Ruben Barkow-Kuder
+- Cole Brown

--- a/remove-old-kernels.sh
+++ b/remove-old-kernels.sh
@@ -1,40 +1,134 @@
-#!/bin/bash -e
-# Run this script without any arguments for a dry run
-# Run the script with root and with the argument exec to really remove
-# the list of old kernels and modules printed in the dry run
-# authors: alex Burdusel and @eitch on https://askubuntu.com/a/1409370/34298
+#!/usr/bin/env bash
 
-uname -a
+# -o pipefail = set exit code of a sequence of piped commands to an error if any of them errored
+# -e          = exit on first error
+set -eo pipefail
+
+_script_path="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+RED='\033[0;31m'
+URED='\033[4;31m' # underlined
+NC='\033[0m' # No Color
+
+#--------------------------------------------------------------------------------
+# Current Kernel Info & Scary Warning
+#--------------------------------------------------------------------------------
+
+echo "╔═══════════════════════════════════════════════════════════════════════════════╗"
+echo -e "║ WARNING: ${RED}Reboot${NC} after installing a new kernel and ${URED}before${NC} running this script! ║"
+echo "╚═══════════════════════════════════════════════════════════════════════════════╝"
+
+echo
+echo "─current───────────────────────────────────"
+echo
+echo "Full system info:"
+echo "  $(uname -a)"
+
 IN_USE=$(uname -a | awk '{ print $3 }')
-echo "Your in use kernel is $IN_USE"
-echo "Be sure to restart the system after a new kernel install before running this script!"
+echo
+echo "Your in use kernel is version:"
+echo "  $IN_USE"
 
+#--------------------------------------------------------------------------------
+# Get Lists of Old Kernel Packages & Modules
+#--------------------------------------------------------------------------------
+
+echo
+echo "─old───────────────────────────────────"
+
+# Want to give feedback for null case if this fails so unset exit-on-error for a sec.
+set +e
 OLD_KERNELS=$(
     dpkg --get-selections |
+        grep -Ei 'linux-image|linux-headers|linux-modules' |
         grep -v "linux-headers-generic" |
         grep -v "linux-image-generic" |
         grep -v "linux-image-amd64" |
         grep -v "linux-image-arm64" |
         grep -v "${IN_USE%%-generic}" |
-        grep -Ei 'linux-image|linux-headers|linux-modules' |
         awk '{ print $1 }'
 )
-echo "Old Kernels to be removed:"
-echo "$OLD_KERNELS"
+declare -i EXIT_CODE=$?
+set -e
 
+echo
+echo "Old kernels to be removed:"
+if [[ $EXIT_CODE -ne 0 ]]; then
+    if [[ ! -z "$OLD_KERNELS" ]]; then
+        echo "ERROR finding kernels?"
+        exit $EXIT_CODE
+    else
+        NO_KERNEL_ACTION="true"
+        echo "  - None."
+    fi
+else
+    for PACKAGE in $OLD_KERNELS; do
+        echo "  - $PACKAGE"
+    done
+fi
+
+# Same null feedback thing.
+set +e
 OLD_MODULES=$(
     ls /lib/modules |
-    grep -v "${IN_USE%%-generic}" |
-    grep -v "${IN_USE}"
+        grep -v "${IN_USE%%-generic}" |
+        grep -v "${IN_USE}"
 )
-echo "Old Modules to be removed:"
-echo "$OLD_MODULES"
+EXIT_CODE=$?
+set -e
+
+echo
+echo "Old modules to be removed:"
+
+if [[ $EXIT_CODE -ne 0 ]]; then
+    if [[ ! -z "$OLD_MODULES" ]]; then
+        echo "ERROR finding modules?"
+        exit $EXIT_CODE
+    else
+        NO_MODULE_ACTION="true"
+        echo "  - None."
+    fi
+else
+    for MODULE in $OLD_KERNELS; do
+        echo "  - $MODULE"
+    done
+fi
+
+#--------------------------------------------------------------------------------
+# Execute or Dry Run?
+#--------------------------------------------------------------------------------
 
 if [ "$1" == "exec" ]; then
-  apt-get purge $OLD_KERNELS
-  for module in $OLD_MODULES ; do
-    rm -rf /lib/modules/$module/
-  done
+    echo
+    echo "─rm─kernel─packages─────────────────────"
+    if [[ -z "$OLD_KERNELS" ]]; then
+        echo "  No old kernels; nothing to remove."
+    else
+        set -x
+        echo apt-get purge $OLD_KERNELS
+        # Unset cmd echo flag without echoing the unsetting of said flag.
+        {
+            set +x
+        } 2>/dev/null
+    fi
+
+    echo
+    echo "─rm─kernel─modules──────────────────────"
+    if [[ -z "$OLD_MODULES" ]]; then
+        echo "  No old modules; nothing to remove."
+    else
+        for module in $OLD_MODULES ; do
+            set -x
+            echo rm -rf /lib/modules/$module/
+            {
+                set +x
+            } 2>/dev/null
+        done
+    fi
 else
-    echo "If all looks good, run it again like this: sudo $0 exec"
+    echo
+    echo "─dry─run─complete───────────────────────"
+    echo
+    echo "If all looks good, run it again like this:"
+    echo "  sudo $0 exec"
 fi


### PR DESCRIPTION
Shouldn't be any change in actual functionality.

---

Added "WARNING", coloring, & underlining of keywords in the restart warning.

Broke output into sections.

Added ASCII box drawing characters so the sections pop out at your eyes in the terminal.

Moved the biggest `grep` culling of the `dpkg` list up to be first.

Added feedback for when you have no old kernels/modules to both the finding and the (lack of) removal steps.

Normalized indents to 4 chars from either 4 or 2.

---
output:

main@work-2021-lap:~/ocean/code/remove-old-kernels$ sudo ./remove-old-kernels.sh
╔═══════════════════════════════════════════════════════════════════════════════╗
║ WARNING: Reboot after installing a new kernel and before running this script! ║
╚═══════════════════════════════════════════════════════════════════════════════╝

─current───────────────────────────────────

Full system info:
  Linux work-2021-lap 6.8.0-45-generic #45~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Wed Sep 11 15:25:05 UTC 2 x86_64 x86_64 x86_64 GNU/Linux

Your in use kernel is version:
  6.8.0-45-generic

─old───────────────────────────────────

Old kernels to be removed:
  - None.

Old modules to be removed:
  - None.

─dry─run─complete───────────────────────

If all looks good, run it again like this:
  sudo ./remove-old-kernels.sh exec
main@work-2021-lap:~/ocean/code/remove-old-kernels$ sudo ./remove-old-kernels.sh exec
╔═══════════════════════════════════════════════════════════════════════════════╗
║ WARNING: Reboot after installing a new kernel and before running this script! ║
╚═══════════════════════════════════════════════════════════════════════════════╝

─current───────────────────────────────────

Full system info:
  Linux work-2021-lap 6.8.0-45-generic #45~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Wed Sep 11 15:25:05 UTC 2 x86_64 x86_64 x86_64 GNU/Linux

Your in use kernel is version:
  6.8.0-45-generic

─old───────────────────────────────────

Old kernels to be removed:
  - None.

Old modules to be removed:
  - None.

─rm─kernel─packages─────────────────────
  No old kernels; nothing to remove.

─rm─kernel─modules──────────────────────
  No old modules; nothing to remove.
